### PR TITLE
mouseStatusHandler missing parameter (int nWheelMove)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 # Faux86: A portable, open-source 8086 PC emulator for bare metal Raspberry Pi
-Faux86 is designed to be run 'bare metal' on a Raspberry Pi. This means that the emulator runs directly on the hardware so no OS needs to booted on the Pi. 
+Faux86 is designed to be run 'bare metal' on a Raspberry Pi. This means that the emulator runs directly on the hardware so no supporting OS needs to be booted on the Pi.
+
+## NOTE:
+This release is very old and the project has not received any updates in quite a few years.
+A newer release is now available on my project page named [Fake860-remake](https://github.com/ArnoldUK/Faux86-remake).
+The newer release is still work in progress but addresses many issues including:
+- Improved emulation speed.
+- Improved video rendering and mode switching.
+- Improved audio.
+- Updated BIOS for PCXT and Video.
+- Updated disk and file access, including writeable disk images.
+- More configuration parameters
+- Fully working mouse control in both DOS and Windows.
+- Many bug fixes.
 
 ## Features
 - 8086 and 80186 instruction set emulation

--- a/pi/CircleHostInterface.cpp
+++ b/pi/CircleHostInterface.cpp
@@ -255,7 +255,7 @@ void CircleHostInterface::queueEvent(EventType eventType, u16 scancode)
 	}
 }
 
-void CircleHostInterface::mouseStatusHandler (unsigned nButtons, int nDisplacementX, int nDisplacementY)
+void CircleHostInterface::mouseStatusHandler (unsigned nButtons, int nDisplacementX, int nDisplacementY, int nWheelMove)
 {
 	InputEvent newEvent;
 	

--- a/pi/CircleHostInterface.h
+++ b/pi/CircleHostInterface.h
@@ -119,7 +119,7 @@ namespace Faux86
 		void queueEvent(InputEvent& inEvent);
 		void queueEvent(EventType eventType, u16 scancode);
 		
-		static void mouseStatusHandler (unsigned nButtons, int nDisplacementX, int nDisplacementY);
+		static void mouseStatusHandler (unsigned nButtons, int nDisplacementX, int nDisplacementY, int nWheelMove);
 		static void keyStatusHandlerRaw (unsigned char ucModifiers, const unsigned char RawKeys[6]);
 
 		CircleFrameBufferInterface frameBuffer;


### PR DESCRIPTION
I've updated the CircleHostInterface.cpp and CircleHostInterface.h within the the pi folder.
The mouseStatusHandler was missing an extra parameter (int nWheelMove) and the source code would not compile with the circle library.